### PR TITLE
Fix typo: required: → required =

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The `required` metadata ensures component dependencies are met:
 
 ```ts
 class SpriteComponent extends Component {
-  required: [TransformComponent]
+  required = [TransformComponent]
 
   create() {
     // If there's no TransformComponent, this will throw an error


### PR DESCRIPTION
Fixed syntax error in Component example.

## Change
Line 236: Changed type declaration to assignment

**Before:** `required: [TransformComponent]`
**After:** `required = [TransformComponent]`

This should be an assignment, not a type declaration.

Closes #20

---

If this PR helped your project, tips are appreciated! 🙏
USDT (TRC20): `TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`